### PR TITLE
Profile avatar upload, primary address star, and category admin — icon upload & details

### DIFF
--- a/api/admin/products.js
+++ b/api/admin/products.js
@@ -46,6 +46,44 @@ module.exports = function makeAdminProductsRouter({ db, helpers }) {
   });
 
   // ------------------------------
+  // Upload: category icon
+  // POST /api/upload/category-icon
+  // ------------------------------
+  const categoryIconStorage = multer.diskStorage({
+    destination(req, file, cb) {
+      const folder = path.join(__dirname, '..', '..', 'static', 'uploads', 'categories');
+      helpers.ensureDir(folder);
+      cb(null, folder);
+    },
+    filename(req, file, cb) {
+      const ext = path.extname(file.originalname || '').toLowerCase() || '.jpg';
+      const name = crypto.randomBytes(16).toString('hex') + ext;
+      cb(null, name);
+    }
+  });
+
+  const categoryIconUpload = multer({
+    storage: categoryIconStorage,
+    limits: { files: 1, fileSize: 5 * 1024 * 1024 },
+    fileFilter(req, file, cb) {
+      const ok = /^image\/(jpeg|png|webp)$/.test(file.mimetype);
+      cb(ok ? null : new Error('ONLY_IMAGES'), ok);
+    }
+  });
+
+  router.post('/upload/category-icon', categoryIconUpload.single('icon'), (req, res) => {
+    try {
+      const file = req.file;
+      if (!file) return res.status(400).json({ ok: false, error: 'ICON_REQUIRED' });
+      const url = `/static/uploads/categories/${file.filename}`;
+      res.json({ ok: true, url });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ ok: false, error: 'UPLOAD_ERROR' });
+    }
+  });
+
+  // ------------------------------
   // Categories: /api/prod_categories
   // ------------------------------
   router.get('/prod_categories', async (req, res) => {

--- a/api/public/shop.js
+++ b/api/public/shop.js
@@ -1,8 +1,36 @@
 const express = require('express');
 const crypto = require('crypto');
+const path = require('path');
+const multer = require('multer');
 
 module.exports = function makePublicShopRouter({ db, helpers }) {
   const router = express.Router();
+
+  // ------------------------------
+  // Upload: customer avatar
+  // POST /api/public/me/photo (field: photo|avatar)
+  // ------------------------------
+  const avatarStorage = multer.diskStorage({
+    destination(req, file, cb) {
+      const folder = path.join(__dirname, '..', '..', 'static', 'uploads', 'avatars');
+      helpers.ensureDir(folder);
+      cb(null, folder);
+    },
+    filename(req, file, cb) {
+      const ext = path.extname(file.originalname || '').toLowerCase() || '.jpg';
+      const name = `${Date.now()}-${crypto.randomBytes(8).toString('hex')}${ext}`;
+      cb(null, name);
+    }
+  });
+
+  const avatarUpload = multer({
+    storage: avatarStorage,
+    limits: { files: 1, fileSize: 5 * 1024 * 1024 },
+    fileFilter(req, file, cb) {
+      const ok = /^image\/(jpeg|png|webp)$/.test(file.mimetype);
+      cb(ok ? null : new Error('ONLY_IMAGES'), ok);
+    }
+  });
 
   // ------------------------------
   // small utils (local)
@@ -91,6 +119,7 @@ module.exports = function makePublicShopRouter({ db, helpers }) {
          c.name,
          c.phone,
          DATE_FORMAT(c.birthday, '%Y-%m-%d') AS birthday,
+         c.photo,
          c.is_active
        FROM cust_customer_sessions s
        JOIN cust_customers c
@@ -115,6 +144,7 @@ module.exports = function makePublicShopRouter({ db, helpers }) {
       name: r.name,
       phone: r.phone,
       birthday: r.birthday || null,
+      photo: r.photo || null,
     };
   }
 
@@ -211,7 +241,7 @@ module.exports = function makePublicShopRouter({ db, helpers }) {
       );
 
       const [me] = await db.query(
-        `SELECT id, name, phone, DATE_FORMAT(birthday, '%Y-%m-%d') AS birthday
+        `SELECT id, name, phone, DATE_FORMAT(birthday, '%Y-%m-%d') AS birthday, photo
          FROM cust_customers
          WHERE tenant_id=? AND id=?
          LIMIT 1`,
@@ -287,6 +317,43 @@ module.exports = function makePublicShopRouter({ db, helpers }) {
       res.status(500).json({ ok: false, error: 'DB_ERROR' });
     }
   });
+
+  // POST /api/public/me/photo (multipart/form-data, field: photo|avatar)
+  router.post(
+    '/me/photo',
+    avatarUpload.fields([
+      { name: 'photo', maxCount: 1 },
+      { name: 'avatar', maxCount: 1 }
+    ]),
+    async (req, res) => {
+      try {
+        const tenantId = helpers.getTenantId(req);
+        const token = str(req.headers['x-customer-token']);
+        const customer = await getCustomerByToken(tenantId, token);
+        if (!customer) return res.status(401).json({ ok: false, error: 'UNAUTHORIZED' });
+
+        const file =
+          (req.files && req.files.photo && req.files.photo[0]) ||
+          (req.files && req.files.avatar && req.files.avatar[0]);
+
+        if (!file) return res.status(400).json({ ok: false, error: 'PHOTO_REQUIRED' });
+
+        const photoUrl = `/static/uploads/avatars/${file.filename}`;
+
+        await db.query(
+          `UPDATE cust_customers
+           SET photo=?
+           WHERE tenant_id=? AND id=?`,
+          [photoUrl, tenantId, customer.id]
+        );
+
+        res.json({ ok: true, photoUrl });
+      } catch (e) {
+        console.error(e);
+        res.status(500).json({ ok: false, error: 'DB_ERROR' });
+      }
+    }
+  );
 
   // GET /api/public/me/addresses
   router.get('/me/addresses', async (req, res) => {

--- a/static/css/shop.css
+++ b/static/css/shop.css
@@ -1182,6 +1182,33 @@ html[data-theme="dark"] .qty-pill--muted .qty-pill__btn:hover{
   border-radius: 16px;
   border: 1px solid var(--color-border);
   background: var(--color-surface-2);
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+}
+
+.shop-profile-photo-img{
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.shop-profile-photo-placeholder{
+  font-size: 12px;
+  color: var(--color-text-muted);
+  text-align: center;
+  padding: 8px;
+}
+
+.shop-profile-photo-btn{
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
+  font-size: 12px;
+  padding: 6px 8px;
 }
 
 .shop-profile-info{
@@ -1246,6 +1273,15 @@ html[data-theme="dark"] .qty-pill--muted .qty-pill__btn:hover{
   display: grid;
   place-items: center;
   cursor: pointer;
+}
+
+.shop-address-action-icon.is-default{
+  color: var(--color-primary);
+}
+
+.shop-address-action-icon.is-default:disabled{
+  opacity: 0.7;
+  cursor: default;
 }
 
 .shop-address-action-icon.is-danger{

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -430,8 +430,33 @@ html[data-sidebar-collapsed="1"] .app-grid{
   border-radius:10px;
   background:var(--color-surface-2);
   color:var(--color-text);
+  overflow:hidden;
 }
 .stage-icon i{color:inherit}
+.stage-icon img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  display:block;
+}
+
+.category-icon{
+  width:32px;
+  height:32px;
+  border-radius:10px;
+  background:var(--color-surface-2);
+  color:var(--color-text);
+  display:grid;
+  place-items:center;
+  overflow:hidden;
+}
+
+.category-icon img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  display:block;
+}
 
 .stage-text strong{display:block;font-weight:900;color:var(--color-text)}
 .stage-text small{display:block;margin-top:2px;color:var(--color-text-muted);font-size:12px}
@@ -987,6 +1012,16 @@ input[type=number]{ -moz-appearance:textfield; }
   place-items:center;
 }
 
+.category-icon-upload{
+  display:grid;
+  gap:8px;
+}
+
+.category-icon-preview{
+  width:120px;
+  height:120px;
+}
+
 .product-photo-placeholder{
   color:var(--color-text-muted);
   font-size:12px;
@@ -1217,10 +1252,12 @@ input[type=number]{ -moz-appearance:textfield; }
 
 /* ================= Fix: Hide product info header when nothing selected ================= */
 /* Работает автоматически через :has() (Chrome/Edge/Safari). */
-#productInfoPanel:has(#productEmpty:not(.hidden)) .product-info-header{
+#productInfoPanel:has(#productEmpty:not(.hidden)) .product-info-header,
+#productInfoPanel:has(#categoryEmpty:not(.hidden)) .product-info-header{
   display: none !important;
 }
-#productInfoPanel:has(#productInfo:not(.hidden)) .product-info-header{
+#productInfoPanel:has(#productInfo:not(.hidden)) .product-info-header,
+#productInfoPanel:has(#categoryInfo:not(.hidden)) .product-info-header{
   display: flex !important;
 }
 /* ================= Shop (витрина): 3 колонки без сайдбара ================= */

--- a/static/js/products.js
+++ b/static/js/products.js
@@ -20,6 +20,8 @@
   // right info
   const productEmpty = $("#productEmpty");
   const productInfo = $("#productInfo");
+  const categoryEmpty = $("#categoryEmpty");
+  const categoryInfo = $("#categoryInfo");
   const closeProductInfoBtn = $("#closeProductInfoBtn");
   const editProductBtn = $("#editProductBtn");
 
@@ -37,6 +39,11 @@
   const infoPhotoPlaceholder = $("#infoPhotoPlaceholder");
   const infoPhotoThumbs = $("#infoPhotoThumbs");
 
+  const categoryIconImg = $("#categoryIconImg");
+  const categoryIconPlaceholder = $("#categoryIconPlaceholder");
+  const categoryStatus = $("#categoryStatus");
+  const categoryVisibility = $("#categoryVisibility");
+
   // sheet (mobile)
   const sheet = $("#productSheet");
   const sheetBackdrop = $("#productSheetBackdrop");
@@ -51,6 +58,7 @@
     currentCategoryId: null,
     allCategoryId: null,
     selectedProductId: null,
+    selectedCategoryId: null,
     selectedProductCategories: [], // full objects
   };
 
@@ -79,6 +87,19 @@
     const data = await res.json().catch(() => null);
     if (!res.ok || !data || data.ok === false) throw new Error((data && data.error) || `HTTP_${res.status}`);
     return data.urls || [];
+  }
+
+  async function apiUploadCategoryIcon(file) {
+    const fd = new FormData();
+    fd.append("icon", file);
+    const res = await fetch("/api/upload/category-icon", {
+      method: "POST",
+      headers: { "x-tenant-id": String(TENANT_ID) },
+      body: fd,
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data || data.ok === false) throw new Error((data && data.error) || `HTTP_${res.status}`);
+    return data.url || "";
   }
 
   // ---------------- Accordion (height fix) ----------------
@@ -142,6 +163,7 @@
     const cat = getCurrentCategory();
     setToolbarTitle(cat ? cat.title : "Товары");
     showView("products");
+    showDetailsEmpty();
   }
 
   function enterCategoriesMode() {
@@ -149,6 +171,7 @@
     setToolbarTitle("Категории");
     showView("categories");
     clearProductSelection();
+    showDetailsEmpty();
   }
 
   // ---------------- Load ----------------
@@ -184,6 +207,27 @@
       .replace(/'/g, "&#039;");
   }
 
+  function looksLikeUrl(v) {
+    const s = String(v || "").trim();
+    return (
+      s.startsWith("http://") ||
+      s.startsWith("https://") ||
+      s.startsWith("blob:") ||
+      s.startsWith("data:") ||
+      s.startsWith("/static/") ||
+      s.startsWith("/uploads/")
+    );
+  }
+
+  function renderCategoryIcon(icon, className = "stage-icon") {
+    const v = String(icon || "").trim();
+    if (looksLikeUrl(v)) {
+      return `<span class="${className}"><img src="${escapeHtml(v)}" alt="" /></span>`;
+    }
+    const cls = v || "fas fa-folder";
+    return `<span class="${className}"><i class="${escapeHtml(cls)}"></i></span>`;
+  }
+
   function renderCategoriesNav() {
     if (!categoriesNav) return;
 
@@ -193,11 +237,10 @@
 
     categoriesNav.innerHTML = list.map((c) => {
       const isActive = state.mode === "products" && c.id === state.currentCategoryId;
-      const icon = c.icon ? c.icon : "fas fa-folder";
       return `
         <button class="stage-item ${isActive ? "is-active" : ""}" type="button" data-category-id="${c.id}">
-          <span class="stage-icon"><i class="${icon}"></i></span>
-          <span class="stage-meta stage-text"><b>${escapeHtml(c.title)}</b><small>${escapeHtml(c.code || "")}</small></span>
+          ${renderCategoryIcon(c.icon, "stage-icon")}
+          <span class="stage-meta stage-text"><b>${escapeHtml(c.title)}</b></span>
           <span class="acc-spacer"></span>
         </button>
       `;
@@ -289,16 +332,14 @@
       .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0) || a.id - b.id);
 
     categoriesMainList.innerHTML = list.map((c) => {
-      const icon = c.icon ? c.icon : "fas fa-folder";
+      const active = c.id === state.selectedCategoryId ? "is-active" : "";
       return `
-        <div class="order-row category-row" data-id="${c.id}" draggable="true">
+        <div class="order-row category-row ${active}" data-id="${c.id}" draggable="true">
           <div>
-            <div class="order-num"><i class="${icon}"></i></div>
-            <div class="order-time">${escapeHtml(c.code || "")}</div>
+            ${renderCategoryIcon(c.icon, "category-icon")}
           </div>
           <div>
             <div class="order-line"><b>${escapeHtml(c.title)}</b></div>
-            <div class="order-time">sort: ${escapeHtml(String(c.sort_order ?? ""))}</div>
           </div>
           <div class="pill">${c.is_active ? "Активна" : "Выключена"}</div>
         </div>
@@ -316,8 +357,18 @@
       renderCategoriesMainList();
     });
 
-    // dblclick edit
+    // click select
     $$(".category-row", categoriesMainList).forEach((row) => {
+      row.addEventListener("click", () => {
+        const id = Number(row.dataset.id);
+        const cat = state.categories.find((x) => x.id === id);
+        if (!cat) return;
+        state.selectedCategoryId = id;
+        $$(".category-row", categoriesMainList).forEach((x) => x.classList.toggle("is-active", Number(x.dataset.id) === id));
+        showCategoryDetails(cat);
+      });
+
+      // dblclick edit
       row.addEventListener("dblclick", () => {
         const id = Number(row.dataset.id);
         const cat = state.categories.find((x) => x.id === id);
@@ -402,6 +453,10 @@
 
     productTitle.textContent = p.name || "—";
     productSku.textContent = `Артикул: ${p.sku || "—"}`;
+    if (editProductBtn) {
+      editProductBtn.title = "Редактировать товар";
+      editProductBtn.setAttribute("aria-label", "Редактировать товар");
+    }
 
     productPrice.textContent = formatMoney(p.price);
     productOldPrice.textContent = p.old_price != null ? formatMoney(p.old_price) : "—";
@@ -414,6 +469,8 @@
     renderInfoPhotos(p.photos);
 
     productEmpty && productEmpty.classList.add("hidden");
+    categoryEmpty && categoryEmpty.classList.add("hidden");
+    categoryInfo && categoryInfo.classList.add("hidden");
     productInfo && productInfo.classList.remove("hidden");
 
     const isMobile = window.matchMedia("(max-width: 768px)").matches;
@@ -429,13 +486,70 @@
     }
   }
 
+  function renderCategoryPreview(icon) {
+    if (!categoryIconImg || !categoryIconPlaceholder) return;
+    const v = String(icon || "").trim();
+    if (looksLikeUrl(v)) {
+      categoryIconImg.src = v;
+      categoryIconImg.classList.remove("hidden");
+      categoryIconPlaceholder.classList.add("hidden");
+      categoryIconPlaceholder.textContent = "Нет изображения";
+      return;
+    }
+    categoryIconImg.src = "";
+    categoryIconImg.classList.add("hidden");
+    categoryIconPlaceholder.classList.remove("hidden");
+    categoryIconPlaceholder.innerHTML = v ? `<i class="${escapeHtml(v)}"></i>` : "Нет изображения";
+  }
+
+  function showCategoryDetails(cat) {
+    if (!cat) return;
+
+    productTitle.textContent = cat.title || "—";
+    productSku.textContent = "Категория";
+    if (editProductBtn) {
+      editProductBtn.title = "Редактировать категорию";
+      editProductBtn.setAttribute("aria-label", "Редактировать категорию");
+    }
+
+    if (categoryStatus) categoryStatus.textContent = cat.is_active ? "Активна" : "Выключена";
+    if (categoryVisibility) categoryVisibility.textContent = cat.site_visibility ? "Показывается" : "Скрыта";
+    renderCategoryPreview(cat.icon);
+
+    productEmpty && productEmpty.classList.add("hidden");
+    productInfo && productInfo.classList.add("hidden");
+    categoryEmpty && categoryEmpty.classList.add("hidden");
+    categoryInfo && categoryInfo.classList.remove("hidden");
+
+    const isMobile = window.matchMedia("(max-width: 768px)").matches;
+    if (isMobile && sheetHost && categoryInfo) {
+      sheetHost.innerHTML = "";
+      sheetHost.appendChild(categoryInfo);
+      openSheet();
+    } else {
+      if (detailsDesktopHost && categoryInfo && categoryInfo.parentElement !== detailsDesktopHost) {
+        detailsDesktopHost.appendChild(categoryInfo);
+      }
+      closeSheet();
+    }
+  }
+
+  function showDetailsEmpty() {
+    const showCategory = state.mode === "categories";
+    productInfo && productInfo.classList.add("hidden");
+    categoryInfo && categoryInfo.classList.add("hidden");
+    if (productEmpty) productEmpty.classList.toggle("hidden", showCategory);
+    if (categoryEmpty) categoryEmpty.classList.toggle("hidden", !showCategory);
+    closeSheet();
+  }
+
   function clearProductSelection() {
     state.selectedProductId = null;
+    state.selectedCategoryId = null;
     state.selectedProductCategories = [];
-    productInfo && productInfo.classList.add("hidden");
-    productEmpty && productEmpty.classList.remove("hidden");
-    closeSheet();
+    showDetailsEmpty();
     if (productsList) $$(".order-row", productsList).forEach((x) => x.classList.remove("is-active"));
+    if (categoriesMainList) $$(".order-row", categoriesMainList).forEach((x) => x.classList.remove("is-active"));
   }
 
   // ---------------- Modal: product (chips + photos) ----------------
@@ -710,6 +824,10 @@
 
   function openCategoryModal({ mode, category }) {
     const isEdit = mode === "edit";
+    const draft = {
+      iconFile: null,
+      iconPreview: "",
+    };
 
     window.AppModal.open({
       title: isEdit ? "Редактировать категорию" : "Новая категория",
@@ -718,11 +836,16 @@
         const form = $("#categoryEditorForm", body);
         if (!form) return false;
 
+        let iconValue = String(form.icon.value || "").trim();
+        if (draft.iconFile) {
+          iconValue = await apiUploadCategoryIcon(draft.iconFile);
+        }
+
         const payload = {
           tenant_id: TENANT_ID,
           title: String(form.title.value || "").trim(),
           code: String(form.code.value || "").trim(),
-          icon: String(form.icon.value || "").trim(),
+          icon: iconValue,
           sort_order: form.sort_order.value === "" ? null : Number(form.sort_order.value),
           is_active: form.is_active.checked ? 1 : 0,
           site_visibility: form.site_visibility.checked ? 1 : 0,
@@ -747,6 +870,13 @@
     const form = $("#categoryEditorForm", window.AppModal.body);
     if (!form) return;
 
+    const ui = {
+      iconPreview: $("#ceIconPreview", window.AppModal.body),
+      iconPlaceholder: $("#ceIconPlaceholder", window.AppModal.body),
+      iconFileInput: $("#ceIconFile", window.AppModal.body),
+      iconUploadBtn: $("#ceIconUploadBtn", window.AppModal.body),
+    };
+
     if (isEdit && category) {
       form.title.value = category.title || "";
       form.code.value = category.code || "";
@@ -755,6 +885,57 @@
       form.is_active.checked = Boolean(category.is_active);
       form.site_visibility.checked = Boolean(category.site_visibility);
     }
+
+    function renderIconPreview(value) {
+      if (!ui.iconPreview || !ui.iconPlaceholder) return;
+      const v = String(value || "").trim();
+      if (looksLikeUrl(v)) {
+        ui.iconPreview.src = v;
+        ui.iconPreview.classList.remove("hidden");
+        ui.iconPlaceholder.classList.add("hidden");
+        ui.iconPlaceholder.textContent = "Нет изображения";
+        return;
+      }
+      ui.iconPreview.src = "";
+      ui.iconPreview.classList.add("hidden");
+      ui.iconPlaceholder.classList.remove("hidden");
+      ui.iconPlaceholder.innerHTML = v ? `<i class="${escapeHtml(v)}"></i>` : "Нет изображения";
+    }
+
+    renderIconPreview(form.icon.value);
+
+    if (ui.iconUploadBtn && ui.iconFileInput) {
+      ui.iconUploadBtn.addEventListener("click", () => ui.iconFileInput.click());
+      ui.iconFileInput.addEventListener("change", () => {
+        const file = ui.iconFileInput.files && ui.iconFileInput.files[0];
+        ui.iconFileInput.value = "";
+        if (!file) return;
+        const allowed = ["image/jpeg", "image/png", "image/webp"];
+        if (!allowed.includes(file.type)) {
+          alert("Можно загрузить только JPG, PNG или WEBP");
+          return;
+        }
+        if (file.size > 5 * 1024 * 1024) {
+          alert("Размер файла не должен превышать 5MB");
+          return;
+        }
+        if (draft.iconPreview) {
+          try { URL.revokeObjectURL(draft.iconPreview); } catch {}
+        }
+        draft.iconFile = file;
+        draft.iconPreview = URL.createObjectURL(file);
+        renderIconPreview(draft.iconPreview);
+      });
+    }
+
+    form.icon.addEventListener("input", () => {
+      if (draft.iconPreview) {
+        try { URL.revokeObjectURL(draft.iconPreview); } catch {}
+        draft.iconPreview = "";
+        draft.iconFile = null;
+      }
+      renderIconPreview(form.icon.value);
+    });
   }
 
   // ---------------- Sortable (HTML5) ----------------
@@ -822,6 +1003,11 @@
     await loadCategories();
     renderCategoriesNav();
 
+    if (state.selectedCategoryId && !state.categories.some((c) => c.id === state.selectedCategoryId)) {
+      state.selectedCategoryId = null;
+      showDetailsEmpty();
+    }
+
     if (state.mode === "categories") {
       renderCategoriesMainList();
       return;
@@ -880,6 +1066,11 @@
 
     if (editProductBtn) {
       editProductBtn.addEventListener("click", () => {
+        if (state.mode === "categories") {
+          const cat = state.categories.find((x) => x.id === state.selectedCategoryId);
+          if (cat) openCategoryModal({ mode: "edit", category: cat });
+          return;
+        }
         const p = state.products.find((x) => x.id === state.selectedProductId);
         if (p) openProductModal({ mode: "edit", product: p });
       });
@@ -888,8 +1079,13 @@
     window.addEventListener("resize", () => {
       refreshOpenAccordions();
       const isMobile = window.matchMedia("(max-width: 768px)").matches;
-      if (!isMobile && detailsDesktopHost && productInfo && productInfo.parentElement !== detailsDesktopHost) {
-        detailsDesktopHost.appendChild(productInfo);
+      if (!isMobile && detailsDesktopHost) {
+        if (productInfo && productInfo.parentElement !== detailsDesktopHost) {
+          detailsDesktopHost.appendChild(productInfo);
+        }
+        if (categoryInfo && categoryInfo.parentElement !== detailsDesktopHost) {
+          detailsDesktopHost.appendChild(categoryInfo);
+        }
         closeSheet();
       }
     });

--- a/static/js/shop.js
+++ b/static/js/shop.js
@@ -691,6 +691,7 @@
     effectiveList.forEach((a) => {
       const row = document.createElement("div");
       row.className = "shop-address-row";
+      if (Number(a.is_default) === 1) row.classList.add("is-default");
 
       const isSelected = state.selectedAddress
         ? (a.id && state.selectedAddress.id ? Number(a.id) === Number(state.selectedAddress.id) : !!a._local && !!state.selectedAddress._local)
@@ -709,12 +710,6 @@
       const titleEl = document.createElement("div");
       titleEl.className = "shop-address-card-title";
       titleEl.appendChild(document.createTextNode(title || ""));
-      if (token && Number(a.is_default) === 1) {
-        const badge = document.createElement("span");
-        badge.className = "muted";
-        badge.textContent = " • основной";
-        titleEl.appendChild(badge);
-      }
       main.appendChild(titleEl);
 
       if (sub) {
@@ -726,6 +721,29 @@
 
       const actions = document.createElement("div");
       actions.className = "shop-address-actions shop-address-actions--compact";
+
+      if (token) {
+        const btnDef = document.createElement("button");
+        btnDef.type = "button";
+        btnDef.className = "shop-address-action-icon is-default";
+        btnDef.title = Number(a.is_default) === 1 ? "Основной адрес" : "Сделать основным";
+        btnDef.innerHTML = `<i class="fas fa-star"></i>`;
+        if (Number(a.is_default) !== 1) {
+          btnDef.addEventListener("click", async (e) => {
+            e.stopPropagation();
+            try {
+              await apiJson(`/api/public/me/addresses/${a.id}/default`, { method: "PUT" });
+              await refreshAddressState();
+              renderAddressList();
+            } catch (e) {
+              alert("Не удалось изменить основной адрес");
+            }
+          });
+        } else {
+          btnDef.disabled = true;
+        }
+        actions.appendChild(btnDef);
+      }
 
       const btnEdit = document.createElement("button");
       btnEdit.type = "button";
@@ -1965,6 +1983,7 @@
       effectiveList.forEach((a) => {
         const row = document.createElement("div");
         row.className = "shop-address-row";
+        if (Number(a.is_default) === 1) row.classList.add("is-default");
 
         const isSelected = state.selectedAddress
           ? (a.id && state.selectedAddress.id ? Number(a.id) === Number(state.selectedAddress.id) : !!a._local && !!state.selectedAddress._local)
@@ -1983,12 +2002,6 @@
         const titleEl = document.createElement("div");
         titleEl.className = "shop-address-card-title";
         titleEl.appendChild(document.createTextNode(title || ""));
-        if (token && Number(a.is_default) === 1) {
-          const badge = document.createElement("span");
-          badge.className = "muted";
-          badge.textContent = " • основной";
-          titleEl.appendChild(badge);
-        }
         main.appendChild(titleEl);
 
         if (sub) {
@@ -2000,6 +2013,29 @@
 
         const actions = document.createElement("div");
         actions.className = "shop-address-actions shop-address-actions--compact";
+
+        if (token) {
+          const btnDef = document.createElement("button");
+          btnDef.type = "button";
+          btnDef.className = "shop-address-action-icon is-default";
+          btnDef.title = Number(a.is_default) === 1 ? "Основной адрес" : "Сделать основным";
+          btnDef.innerHTML = `<i class="fas fa-star"></i>`;
+          if (Number(a.is_default) !== 1) {
+            btnDef.addEventListener("click", async (e) => {
+              e.stopPropagation();
+              try {
+                await apiJson(`/api/public/me/addresses/${a.id}/default`, { method: "PUT" });
+                await refreshAddressState();
+                renderSheetAddressList();
+              } catch (e) {
+                alert("Не удалось изменить основной адрес");
+              }
+            });
+          } else {
+            btnDef.disabled = true;
+          }
+          actions.appendChild(btnDef);
+        }
 
         const btnEdit = document.createElement("button");
         btnEdit.type = "button";
@@ -2322,6 +2358,29 @@
 
     const photo = document.createElement("div");
     photo.className = "shop-profile-photo";
+
+    const photoImg = document.createElement("img");
+    photoImg.className = "shop-profile-photo-img hidden";
+    photoImg.alt = "Фото профиля";
+
+    const photoPlaceholder = document.createElement("div");
+    photoPlaceholder.className = "shop-profile-photo-placeholder";
+    photoPlaceholder.textContent = "Фото профиля";
+
+    const photoInput = document.createElement("input");
+    photoInput.type = "file";
+    photoInput.accept = "image/*";
+    photoInput.className = "hidden";
+
+    const photoBtn = document.createElement("button");
+    photoBtn.type = "button";
+    photoBtn.className = "btn shop-profile-photo-btn";
+    photoBtn.textContent = "Загрузить фото";
+
+    photo.appendChild(photoImg);
+    photo.appendChild(photoPlaceholder);
+    photo.appendChild(photoInput);
+    photo.appendChild(photoBtn);
     top.appendChild(photo);
 
     const info = document.createElement("div");
@@ -2550,6 +2609,7 @@
         list.forEach((a) => {
           const row = document.createElement("div");
           row.className = "shop-profile-card shop-profile-card--compact";
+          if (Number(a.is_default) === 1) row.classList.add("is-default");
 
           const txt = [
             `${str(a.street)} ${str(a.house)}`,
@@ -2585,12 +2645,12 @@
           const actions = document.createElement("div");
           actions.className = "shop-address-actions shop-address-actions--compact";
 
+          const bDef = document.createElement("button");
+          bDef.type = "button";
+          bDef.className = "shop-address-action-icon is-default";
+          bDef.title = Number(a.is_default) === 1 ? "Основной адрес" : "Сделать основным";
+          bDef.innerHTML = `<i class="fas fa-star"></i>`;
           if (Number(a.is_default) !== 1) {
-            const bDef = document.createElement("button");
-            bDef.type = "button";
-            bDef.className = "shop-address-action-icon";
-            bDef.title = "Сделать основным";
-            bDef.innerHTML = `<i class="fas fa-star"></i>`;
             bDef.addEventListener("click", async (e) => {
               e.stopPropagation();
               try {
@@ -2601,8 +2661,10 @@
                 alert("Не удалось изменить основной адрес");
               }
             });
-            actions.appendChild(bDef);
+          } else {
+            bDef.disabled = true;
           }
+          actions.appendChild(bDef);
 
           const bEdit = document.createElement("button");
           bEdit.type = "button";
@@ -2711,6 +2773,72 @@
       });
     }
 
+    function setProfilePhoto(url) {
+      const v = str(url || "").trim();
+      if (!v) {
+        photoImg.src = "";
+        photoImg.classList.add("hidden");
+        photoPlaceholder.classList.remove("hidden");
+        return;
+      }
+      photoImg.src = v;
+      photoImg.classList.remove("hidden");
+      photoPlaceholder.classList.add("hidden");
+    }
+
+    setProfilePhoto(me?.photo || "");
+
+    photoBtn.addEventListener("click", () => {
+      photoInput.click();
+    });
+
+    photoInput.addEventListener("change", async () => {
+      const file = photoInput.files && photoInput.files[0];
+      photoInput.value = "";
+      if (!file) return;
+
+      const allowed = ["image/jpeg", "image/png", "image/webp"];
+      if (!allowed.includes(file.type)) {
+        alert("Можно загрузить только JPG, PNG или WEBP");
+        return;
+      }
+      if (file.size > 5 * 1024 * 1024) {
+        alert("Размер файла не должен превышать 5MB");
+        return;
+      }
+
+      const tempUrl = URL.createObjectURL(file);
+      setProfilePhoto(tempUrl);
+
+      photoBtn.disabled = true;
+      photoBtn.textContent = "Загружаем…";
+      try {
+        const token = getCustomerToken();
+        if (!token) throw new Error("UNAUTHORIZED");
+        const fd = new FormData();
+        fd.append("photo", file);
+        const res = await fetch("/api/public/me/photo", {
+          method: "POST",
+          headers: { "x-customer-token": token, "x-tenant-id": String(tenantId) },
+          body: fd,
+        });
+        const json = await res.json().catch(() => null);
+        if (!res.ok || !json || json.ok === false) {
+          throw new Error((json && json.error) || `HTTP_${res.status}`);
+        }
+        const finalUrl = `${json.photoUrl}?t=${Date.now()}`;
+        setProfilePhoto(finalUrl);
+        setCustomerCache({ ...me, photo: json.photoUrl });
+      } catch (e) {
+        alert("Не удалось загрузить фото");
+        setProfilePhoto(me?.photo || "");
+      } finally {
+        photoBtn.disabled = false;
+        photoBtn.textContent = "Загрузить фото";
+        try { URL.revokeObjectURL(tempUrl); } catch {}
+      }
+    });
+
     editSave.addEventListener("click", async () => {
       const v = str(editInput.value).trim();
       if (!v) {
@@ -2748,6 +2876,12 @@
   function attachProfileMenuOutsideClose(menuEl, toggleBtn) {
     if (profileMenuListenerAttached) return;
     profileMenuListenerAttached = true;
+    if (menuEl && !menuEl.__stopClickBound) {
+      menuEl.__stopClickBound = true;
+      menuEl.addEventListener("click", (e) => {
+        e.stopPropagation();
+      });
+    }
     document.addEventListener("click", (e) => {
       if (!menuEl || menuEl.classList.contains("hidden")) return;
       if (toggleBtn && toggleBtn.contains(e.target)) return;
@@ -2826,17 +2960,24 @@
     const header = document.querySelector(".app-modal-header");
     if (!header) return () => {};
 
-    let settingsBtn = header.querySelector(".shop-profile-modal-settings");
+    let actionsWrap = header.querySelector(".shop-profile-header-actions");
+    if (!actionsWrap) {
+      actionsWrap = document.createElement("div");
+      actionsWrap.className = "shop-profile-header-actions shop-profile-modal-actions";
+      header.appendChild(actionsWrap);
+    }
+
+    let settingsBtn = actionsWrap.querySelector(".shop-profile-modal-settings");
     if (!settingsBtn) {
       settingsBtn = document.createElement("button");
       settingsBtn.type = "button";
       settingsBtn.className = "btn btn-icon shop-profile-modal-settings";
       settingsBtn.innerHTML = `<i class="fas fa-gear"></i>`;
       settingsBtn.setAttribute("aria-label", "Настройки профиля");
-      header.appendChild(settingsBtn);
+      actionsWrap.appendChild(settingsBtn);
     }
 
-    let menu = header.querySelector(".shop-profile-menu");
+    let menu = actionsWrap.querySelector(".shop-profile-menu");
     if (!menu) {
       menu = document.createElement("div");
       menu.className = "shop-profile-menu hidden";
@@ -2844,7 +2985,7 @@
         <button class="shop-profile-menu-item" data-role="edit" type="button">Редактировать профиль</button>
         <button class="shop-profile-menu-item" data-role="logout" type="button">Выйти</button>
       `;
-      header.appendChild(menu);
+      actionsWrap.appendChild(menu);
     }
 
     const editBtn = menu.querySelector('[data-role="edit"]');
@@ -2861,6 +3002,10 @@
       menu.classList.toggle("hidden");
     };
 
+    menu.addEventListener("click", (e) => {
+      e.stopPropagation();
+    });
+
     if (editBtn) editBtn.onclick = () => {
       menu.classList.add("hidden");
       if (typeof onEdit === "function") onEdit();
@@ -2875,8 +3020,7 @@
 
     return () => {
       document.removeEventListener("click", onDocClick);
-      settingsBtn?.remove();
-      menu?.remove();
+      actionsWrap?.remove();
     };
   }
 

--- a/views/partials/products/center.ejs
+++ b/views/partials/products/center.ejs
@@ -148,19 +148,26 @@
 
     <div class="form-row-2">
       <div>
-        <label class="field-label" for="ce_code">Code</label>
-        <input class="control" id="ce_code" name="code" type="text" placeholder="burgers" />
+        <label class="field-label" for="ce_icon">Icon (FontAwesome)</label>
+        <input class="control" id="ce_icon" name="icon" type="text" placeholder="fas fa-hamburger" />
       </div>
       <div>
-        <label class="field-label" for="ce_icon">Icon</label>
-        <input class="control" id="ce_icon" name="icon" type="text" placeholder="fas fa-hamburger" />
+        <label class="field-label">Фото категории</label>
+        <div class="category-icon-upload">
+          <div class="product-photo-main category-icon-preview">
+            <img id="ceIconPreview" class="product-photo-img hidden" alt="" />
+            <div class="product-photo-placeholder" id="ceIconPlaceholder">Нет изображения</div>
+          </div>
+          <input id="ceIconFile" type="file" accept="image/*" class="hidden" />
+          <button class="btn" type="button" id="ceIconUploadBtn">
+            <i class="fas fa-image"></i> Загрузить
+          </button>
+        </div>
       </div>
     </div>
 
-    <div>
-      <label class="field-label" for="ce_sort">Sort order</label>
-      <input class="control" id="ce_sort" name="sort_order" type="number" step="1" />
-    </div>
+    <input id="ce_code" name="code" type="hidden" />
+    <input id="ce_sort" name="sort_order" type="hidden" />
 
     <div class="form-row-2">
       <label class="switch">

--- a/views/partials/products/info.ejs
+++ b/views/partials/products/info.ejs
@@ -29,6 +29,12 @@
       <div class="empty-text">Нажмите на любой товар для просмотра подробной информации</div>
     </div>
 
+    <div id="categoryEmpty" class="empty-state hidden">
+      <div class="empty-icon"><i class="fas fa-mouse-pointer"></i></div>
+      <div class="empty-title">Выберите категорию</div>
+      <div class="empty-text">Нажмите на категорию слева, чтобы увидеть детали</div>
+    </div>
+
     <!-- Product info -->
     <div id="productInfo" class="hidden">
       <!-- TOP: фото слева, справа info-card -->
@@ -79,6 +85,29 @@
       <div class="info-card">
         <div class="kv-label">Описание</div>
         <div class="kv-value" style="font-weight:500;" id="productDesc">—</div>
+      </div>
+    </div>
+
+    <!-- Category info -->
+    <div id="categoryInfo" class="hidden">
+      <div class="product-info-top">
+        <div class="product-info-photoCol">
+          <div class="product-photo-main">
+            <img id="categoryIconImg" class="product-photo-img hidden" alt="">
+            <div id="categoryIconPlaceholder" class="product-photo-placeholder">Нет изображения</div>
+          </div>
+        </div>
+
+        <div class="info-card">
+          <div class="info-row">
+            <div class="info-text">Статус</div>
+            <div class="info-title" id="categoryStatus">—</div>
+          </div>
+          <div class="info-row">
+            <div class="info-text">На сайте</div>
+            <div class="info-title" id="categoryVisibility">—</div>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- Fix profile settings UX so the settings menu is an overlay and no longer shifts the header when opened.
- Add ability to upload and persist customer avatar images and show a live preview in the profile UI.
- Make the “primary” address visible as an accent-colored star and ensure it updates when changed.
- Improve category admin: show selected category details in the right panel, support uploading category icons, and hide `code`/`sort_order` from the visible form while preserving values on save.

### Description
- Backend: added avatar upload endpoint `POST /api/public/me/photo` and category icon upload `POST /api/upload/category-icon`, storing files under `static/uploads/avatars/` and `static/uploads/categories/` and validating image mime/type/size; updated `cust_customers.photo` usage in responses. (files: `api/public/shop.js`, `api/admin/products.js`).
- Profile UI: added file input, preview, cache-bust on success, upload flow and error handling, and ensured menu toggles use `stopPropagation` and an outside click handler so the menu is overlayed and does not affect header layout. (files: `static/js/shop.js`, `static/css/shop.css`).
- Addresses: render a star button for primary addresses, add `is-default` styling and make the star accent-colored and interactive to change default address without layout shift. (files: `static/js/shop.js`, `static/css/shop.css`).
- Categories/admin UI: hidden `code` and `sort_order` inputs in the modal (kept as hidden fields), added category icon upload and preview in the modal, render category icons as `<img>` when value looks like a URL/path and show category details on the right panel. (files: `static/js/products.js`, `views/partials/products/center.ejs`, `views/partials/products/info.ejs`, `static/css/style.css`).

### Testing
- Started the app with `node server.js`; the HTTP server process launched but the server logged a DB connection error (`ECONNREFUSED`) because no database was reachable, so full end-to-end verification could not be completed. (failed/partial).
- Ran an automated Playwright attempt to open `/dashboard/products`; the run failed with `net::ERR_EMPTY_RESPONSE` because the app endpoint was not fully reachable due to the server/DB state. (failed).
- No other automated unit or integration tests were executed in this run. (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960ed7ad5a8832a814ffce29ee73d06)