### PR TITLE
Fix: render option items after picker and remove quantity inputs from assignments

### DIFF
--- a/static/js/products.js
+++ b/static/js/products.js
@@ -1197,15 +1197,12 @@
     }
 
     optionAssignmentsList.innerHTML = assignments.map((assignment) => {
-      const controlsDisabled = !editable;
       const assignmentKey = assignment.tempId ?? assignment.id;
       return `
         <div class="option-assignment-row">
           <div>
             <div class="options-row-title">${escapeHtml(assignment.product_name || assignment.name || "")}</div>
           </div>
-          <input class="control" type="number" min="0" value="${assignment.priority ?? 0}" data-assignment-field="priority" data-assignment-id="${assignmentKey}" ${controlsDisabled ? "disabled" : ""} />
-          <input class="control" type="number" min="0" value="${assignment.sort_order ?? 0}" data-assignment-field="sort_order" data-assignment-id="${assignmentKey}" ${controlsDisabled ? "disabled" : ""} />
           ${editable ? `<button class="btn btn-icon" type="button" data-assignment-remove="${assignmentKey}" title="Удалить"><i class="fas fa-times"></i></button>` : "<div></div>"}
         </div>
       `;
@@ -1233,30 +1230,6 @@
         }
         await loadOptionGroups();
         renderOptionGroupsList();
-      });
-    });
-
-    const debounceMap = new Map();
-    optionAssignmentsList.querySelectorAll("input[data-assignment-field]").forEach((input) => {
-      input.addEventListener("input", () => {
-        const field = input.dataset.assignmentField;
-        const id = input.dataset.assignmentId;
-        if (state.optionPanel.mode === "create") {
-          const item = state.optionDraft.assignments.find((x) => String(x.tempId) === String(id));
-          if (!item || !field) return;
-          item[field] = input.value === "" ? 0 : Number(input.value);
-          return;
-        }
-
-        const assignmentId = Number(id);
-        if (!Number.isFinite(assignmentId) || !field) return;
-        const value = input.value === "" ? 0 : Number(input.value);
-        const current = debounceMap.get(assignmentId);
-        if (current) clearTimeout(current);
-        const timer = setTimeout(async () => {
-          await apiPatchAssignment(assignmentId, { [field]: value });
-        }, 400);
-        debounceMap.set(assignmentId, timer);
       });
     });
     refreshOpenAccordions();
@@ -1288,6 +1261,8 @@
     if (optionAssignmentsAddBtn) optionAssignmentsAddBtn.classList.toggle("hidden", !editable);
 
     updateOptionGroupSelectionUi();
+    // fix: re-render items after picker apply; missing call kept list empty.
+    renderOptionItems(getOptionItemsSource());
     renderOptionAssignments(getOptionAssignmentsSource());
     renderOptionHeader();
   }


### PR DESCRIPTION
### Motivation
- Restore functionality where selected products in the `items` picker actually appear in the group editor so prices can be edited. 
- Remove unnecessary numeric `qty`/limit fields from the `assignments` UI which were introduced by recent changes. 
- Keep backend API and data schema unchanged and apply a minimal UI wiring fix. 
- Add a short explanatory comment at the fix site to document the regression cause. 

### Description
- Ensure option items are re-rendered after picker apply by calling `renderOptionItems(getOptionItemsSource())` from `renderOptionGroupLevel`. 
- Remove numeric input controls (`priority`/`sort_order` numeric inputs) from `renderOptionAssignments` so assignments show only product info and the delete button. 
- Remove the associated debounced input handlers and server patch calls for assignment numeric fields to avoid showing/enabling quantity controls in assignments. 
- Added an inline comment `// fix: re-render items after picker apply; missing call kept list empty.` to mark the regression fix. 

### Testing
- No automated tests were run in this change set. 
- Changes are limited to `static/js/products.js` and do not modify API routes or DB interactions. 
- Manual runtime verification was not performed in this environment. 
- Recommend smoke-testing in a dev build to confirm picked items appear and assignments no longer show quantity inputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696240bbc38c832a8438b329ced2e930)