### PR TITLE
Options panel: 3-way selection UI, per-item limits, header active switch, compact rows

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -963,6 +963,31 @@ input[type=number]{ -moz-appearance:textfield; }
   padding:14px;
   border:1px solid #eef1f6;
 }
+.option-group-row{
+  display:flex;
+  align-items:flex-start;
+  gap:12px;
+  min-width:0;
+}
+.option-group-title-field{
+  flex:1 1 50%;
+  min-width:0;
+}
+.option-group-title-field .control{
+  min-width:0;
+  text-overflow:ellipsis;
+  overflow:hidden;
+  white-space:nowrap;
+}
+.option-group-select-field{
+  flex:0 0 220px;
+}
+.option-header-switch{
+  margin-right:4px;
+}
+.option-header-switch .switch-text{
+  font-size:12px;
+}
 .option-group-section+.option-group-section{margin-top:16px;}
 .section-header{
   display:flex;
@@ -980,10 +1005,13 @@ input[type=number]{ -moz-appearance:textfield; }
   gap:10px;
   align-items:center;
   padding:10px;
+  padding-right:36px;
   border-radius:10px;
   background:#fff;
   border:1px solid #eef1f6;
   min-width:0;
+  position:relative;
+  overflow:hidden;
 }
 .option-item-row{
   display:flex;
@@ -996,8 +1024,9 @@ input[type=number]{ -moz-appearance:textfield; }
   min-width:0;
 }
 .option-item-title{
-  flex:1;
+  flex:1 1 50%;
   min-width:0;
+  max-width:50%;
 }
 .option-item-title .options-row-title{
   white-space:nowrap;
@@ -1021,15 +1050,24 @@ input[type=number]{ -moz-appearance:textfield; }
   min-width:0;
 }
 .option-item-qty-field{
+  position:relative;
   display:flex;
   align-items:center;
   gap:4px;
   font-size:11px;
   color:#6b7280;
   white-space:nowrap;
+  padding-top:6px;
 }
 .option-item-qty-label{
   text-transform:lowercase;
+  position:absolute;
+  top:-6px;
+  left:6px;
+  padding:0 4px;
+  background:#fff;
+  font-size:10px;
+  color:#9ca3af;
 }
 .option-item-price{
   display:flex;
@@ -1041,10 +1079,6 @@ input[type=number]{ -moz-appearance:textfield; }
   justify-content:flex-end;
   white-space:nowrap;
 }
-.option-item-catalog{
-  font-size:12px;
-  color:#6b7280;
-}
 .option-item-price-value{
   display:inline-block;
   max-width:120px;
@@ -1052,14 +1086,21 @@ input[type=number]{ -moz-appearance:textfield; }
   text-overflow:ellipsis;
   white-space:nowrap;
   text-align:right;
+  font-size:12px;
 }
 .option-item-price-value.is-accent{
   font-weight:600;
   color:#111827;
+  font-size:14px;
+}
+.option-item-price-value.is-muted{
+  color:#9ca3af;
+  font-size:12px;
 }
 .option-item-row .control,.option-assignment-row .control{width:100%;}
 .option-item-qty .control{
-  width:60px;
+  width:54px;
+  padding:4px 6px;
 }
 .option-item-price .control{
   width:90px;
@@ -1078,6 +1119,53 @@ input[type=number]{ -moz-appearance:textfield; }
   display:flex;
   align-items:center;
   gap:12px;
+}
+.option-row-remove{
+  position:absolute;
+  right:8px;
+  top:50%;
+  transform:translateY(-50%);
+  border:none;
+  background:transparent;
+  color:#9ca3af;
+  padding:4px;
+  cursor:pointer;
+}
+.option-row-remove:hover{
+  color:#ef4444;
+}
+.option-row-remove:focus-visible{
+  outline:2px solid #c7d2fe;
+  outline-offset:2px;
+}
+.option-item-row .control.is-invalid{
+  border-color:#fca5a5;
+}
+.option-assignment-row .control.is-invalid{
+  border-color:#fca5a5;
+}
+.app-toast{
+  position:fixed;
+  right:20px;
+  bottom:20px;
+  background:#111827;
+  color:#fff;
+  padding:10px 14px;
+  border-radius:10px;
+  box-shadow:0 10px 24px rgba(15,23,42,.24);
+  font-size:13px;
+  z-index:3000;
+  opacity:0;
+  transform:translateY(8px);
+  transition:opacity .2s ease, transform .2s ease;
+  pointer-events:none;
+}
+.app-toast.is-visible{
+  opacity:1;
+  transform:translateY(0);
+}
+.app-toast.is-error{
+  background:#ef4444;
 }
 .option-picker-tabs{
   display:flex;

--- a/static/js/products.js
+++ b/static/js/products.js
@@ -33,6 +33,8 @@
   const optionHeaderPrimaryBtn = $("#optionHeaderPrimaryBtn");
   const optionHeaderDeleteBtn = $("#optionHeaderDeleteBtn");
   const optionHeaderCloseBtn = $("#optionHeaderCloseBtn");
+  const optionHeaderActiveSwitch = $("#optionHeaderActiveSwitch");
+  const optionHeaderActiveInput = $("#optionHeaderActiveInput");
   const closeProductInfoBtn = $("#closeProductInfoBtn");
   const editProductBtn = $("#editProductBtn");
 
@@ -109,10 +111,12 @@
       pickerProducts: [],
       pickerQuery: "",
       pickerTabsScrollLeft: 0,
+      pickerInitialSelection: new Set(),
       returnTo: null,
       formSnapshot: null,
       snapshotMode: null,
       itemsDirty: false,
+      activeToggleBusy: false,
     },
     optionDraft: null,
   };
@@ -447,7 +451,27 @@
   }
 
   function getSelectionLabel(type) {
+    if (type === "multiple_group") return "Несколько (лимит группы)";
+    if (type === "multiple_item") return "Несколько (лимит на товар)";
     return type === "multiple" ? "Несколько" : "Один";
+  }
+
+  function getSelectionUiTypeFromItems(items = []) {
+    const hasItemLimits = items.some((item) => {
+      const min = item.qty_min ?? 1;
+      const max = item.qty_max ?? 1;
+      return min !== 1 || max !== 1;
+    });
+    return hasItemLimits ? "multiple_item" : "multiple_group";
+  }
+
+  function getSelectionUiTypeFromGroup(group, items = []) {
+    if (!group || group.selection_type !== "multiple") return "single";
+    return getSelectionUiTypeFromItems(items);
+  }
+
+  function getSelectionPayloadType(selectionUi) {
+    return selectionUi === "single" ? "single" : "multiple";
   }
 
   function renderCategoryIcon(icon, className = "stage-icon") {
@@ -944,8 +968,13 @@
   }
 
   function getOptionGroupSelectionType() {
-    if (optionGroupSelectionInput) return optionGroupSelectionInput.value === "multiple" ? "multiple" : "single";
-    if (state.optionGroupDetails?.group?.selection_type) return state.optionGroupDetails.group.selection_type;
+    if (optionGroupSelectionInput?.value) return optionGroupSelectionInput.value;
+    if (state.optionPanel.mode === "create" && state.optionDraft?.group) {
+      return state.optionDraft.group.selection_type || "single";
+    }
+    if (state.optionGroupDetails?.group) {
+      return getSelectionUiTypeFromGroup(state.optionGroupDetails.group, state.optionGroupDetails.items || []);
+    }
     return "single";
   }
 
@@ -964,9 +993,10 @@
   }
 
   function getOptionGroupFormValues() {
+    const selectionUi = getOptionGroupSelectionType();
     return {
       title: String(optionGroupTitleInput?.value || "").trim(),
-      selection_type: optionGroupSelectionInput?.value === "multiple" ? "multiple" : "single",
+      selection_type: selectionUi,
       min_select: optionGroupMinInput?.value === "" ? 0 : Number(optionGroupMinInput?.value),
       max_select: optionGroupMaxInput?.value === "" ? null : Number(optionGroupMaxInput?.value),
       is_active: optionGroupActiveInput?.checked ? 1 : 0,
@@ -988,28 +1018,90 @@
   function setOptionGroupFormDisabled(disabled) {
     if (!optionGroupForm) return;
     $$("input, select, textarea", optionGroupForm).forEach((el) => {
-      if (el.type === "checkbox") {
-        el.disabled = disabled;
-      } else {
-        el.disabled = disabled;
+      if (el === optionGroupActiveInput) {
+        el.disabled = state.optionPanel.activeToggleBusy;
+        return;
       }
+      el.disabled = disabled;
     });
   }
 
-  function fillOptionGroupForm(group) {
+  function fillOptionGroupForm(group, items = []) {
     if (!group) return;
     if (optionGroupTitleInput) optionGroupTitleInput.value = group.title || "";
-    if (optionGroupSelectionInput) optionGroupSelectionInput.value = group.selection_type === "multiple" ? "multiple" : "single";
+    if (optionGroupSelectionInput) {
+      if (group.selection_type === "multiple") {
+        optionGroupSelectionInput.value = getSelectionUiTypeFromGroup(group, items);
+      } else if (group.selection_type === "multiple_group" || group.selection_type === "multiple_item") {
+        optionGroupSelectionInput.value = group.selection_type;
+      } else {
+        optionGroupSelectionInput.value = "single";
+      }
+    }
     if (optionGroupMinInput) optionGroupMinInput.value = group.min_select ?? 0;
     if (optionGroupMaxInput) optionGroupMaxInput.value = group.max_select == null ? "" : String(group.max_select);
     if (optionGroupSortInput) optionGroupSortInput.value = group.sort_order ?? 0;
-    if (optionGroupActiveInput) optionGroupActiveInput.checked = Boolean(group.is_active);
+    syncOptionActiveSwitches(Boolean(group.is_active));
   }
 
   function updateOptionGroupSelectionUi() {
-    const selectionType = optionGroupSelectionInput?.value === "multiple" ? "multiple" : "single";
-    if (optionGroupLimitsRow) optionGroupLimitsRow.classList.toggle("hidden", selectionType !== "multiple");
+    const selectionType = getOptionGroupSelectionType();
+    if (optionGroupLimitsRow) optionGroupLimitsRow.classList.toggle("hidden", selectionType !== "multiple_group");
     // NOTE: avoid recursive calls here; we only toggle UI and let callers re-render header.
+  }
+
+  let isSyncingOptionActive = false;
+
+  function syncOptionActiveSwitches(isActive) {
+    isSyncingOptionActive = true;
+    if (optionGroupActiveInput) optionGroupActiveInput.checked = Boolean(isActive);
+    if (optionHeaderActiveInput) optionHeaderActiveInput.checked = Boolean(isActive);
+    isSyncingOptionActive = false;
+  }
+
+  function setOptionActiveBusy(isBusy) {
+    state.optionPanel.activeToggleBusy = isBusy;
+    if (optionGroupActiveInput) optionGroupActiveInput.disabled = isBusy;
+    if (optionHeaderActiveInput) optionHeaderActiveInput.disabled = isBusy;
+  }
+
+  function showToast(message, type = "error") {
+    const existing = document.querySelector(".app-toast");
+    if (existing) existing.remove();
+    const toast = document.createElement("div");
+    toast.className = `app-toast ${type === "error" ? "is-error" : ""}`.trim();
+    toast.textContent = message;
+    document.body.appendChild(toast);
+    requestAnimationFrame(() => toast.classList.add("is-visible"));
+    setTimeout(() => {
+      toast.classList.remove("is-visible");
+      setTimeout(() => toast.remove(), 250);
+    }, 2800);
+  }
+
+  async function handleOptionActiveToggle(nextChecked) {
+    if (isSyncingOptionActive || state.optionPanel.activeToggleBusy) return;
+    const prev = Boolean(state.optionGroupDetails?.group?.is_active ?? state.optionDraft?.group?.is_active);
+    syncOptionActiveSwitches(nextChecked);
+
+    if (state.optionPanel.mode === "create" || !state.selectedOptionGroupId) {
+      if (state.optionDraft?.group) state.optionDraft.group.is_active = nextChecked ? 1 : 0;
+      return;
+    }
+
+    setOptionActiveBusy(true);
+    try {
+      await apiPatchOptionGroup(state.selectedOptionGroupId, { is_active: nextChecked ? 1 : 0 });
+      if (state.optionGroupDetails?.group) state.optionGroupDetails.group.is_active = nextChecked ? 1 : 0;
+      await loadOptionGroups();
+      renderOptionGroupsList();
+    } catch (e) {
+      // revert if update fails
+      syncOptionActiveSwitches(prev);
+      showToast("Не удалось обновить статус опции.");
+    } finally {
+      setOptionActiveBusy(false);
+    }
   }
 
   function renderOptionHeader() {
@@ -1035,9 +1127,13 @@
       } else if (mode === "create") {
         productSku.textContent = "Создание группы опций";
       } else {
-        const selectionLabel = getSelectionLabel(state.optionGroupDetails?.group?.selection_type);
+        const selectionLabel = getSelectionLabel(getOptionGroupSelectionType());
         productSku.textContent = `Тип: ${selectionLabel}`;
       }
+    }
+
+    if (optionHeaderActiveSwitch) {
+      optionHeaderActiveSwitch.classList.toggle("hidden", isPicker);
     }
 
     if (optionHeaderBackBtn) {
@@ -1065,9 +1161,30 @@
         optionHeaderPrimaryBtn.setAttribute("aria-label", "Сохранить");
         if (icon) icon.className = "fas fa-check";
         const formValid = optionGroupForm ? optionGroupForm.checkValidity() : true;
-        optionHeaderPrimaryBtn.disabled = !formValid || !isOptionGroupDirty();
+        const itemLimitsValid = optionItemsList ? !optionItemsList.querySelector(".is-invalid") : true;
+        optionHeaderPrimaryBtn.disabled = !formValid || !itemLimitsValid || !isOptionGroupDirty();
       }
     }
+
+    if (optionHeaderCloseBtn) {
+      const label = mode === "view" ? "Закрыть" : "Отмена изменений";
+      optionHeaderCloseBtn.title = label;
+      optionHeaderCloseBtn.setAttribute("aria-label", label);
+    }
+  }
+
+  function validateItemQtyBounds(row) {
+    const minInput = row.querySelector('input[data-item-field="qty_min"]');
+    const maxInput = row.querySelector('input[data-item-field="qty_max"]');
+    if (!minInput || !maxInput) return;
+    const min = minInput.value === "" ? 0 : Number(minInput.value);
+    const max = maxInput.value === "" ? 0 : Number(maxInput.value);
+    const invalid = Number.isFinite(min) && Number.isFinite(max) && min > max;
+    const message = invalid ? "Минимум не может быть больше максимума." : "";
+    [minInput, maxInput].forEach((input) => {
+      input.setCustomValidity(message);
+      input.classList.toggle("is-invalid", invalid);
+    });
   }
 
   function renderOptionItems(items) {
@@ -1080,6 +1197,7 @@
     }
 
     const selectionType = getOptionGroupSelectionType();
+    const showItemLimits = selectionType === "multiple_item";
     const isDraft = state.optionPanel.mode === "create";
     optionItemsList.innerHTML = items.map((item) => {
       const itemKey = item.tempId ?? item.id;
@@ -1091,7 +1209,7 @@
       const priceValue = hasOverride ? formatPriceInteger(overrideValue) : "";
       const qtyMin = item.qty_min ?? 1;
       const qtyMax = item.qty_max ?? 1;
-      const qtyControls = selectionType === "multiple"
+      const qtyControls = showItemLimits
         ? `
           <div class="option-item-qty">
             <label class="option-item-qty-field">
@@ -1113,19 +1231,29 @@
           </div>
           ${qtyControls}
           <div class="option-item-price">
-            <span class="option-item-catalog ${hasOverride ? "is-muted" : ""}">${hasOverride ? `<s class="option-item-price-value">${catalogPrice}</s>` : `<span class="option-item-price-value">${catalogPrice}</span>`}</span>
-            ${editable ? `
-              <input class="control" type="number" step="1" min="0" aria-label="Новая цена" data-item-field="price" data-item-id="${itemKey}" value="${priceValue}" />
-            ` : `
-              <span class="option-item-price-value ${hasOverride ? "is-accent" : "muted"}">${hasOverride ? priceValue : catalogPrice}</span>
-            `}
+            ${!editable
+              ? `
+                ${hasOverride
+                  ? `<span class="option-item-price-value is-muted">${catalogPrice}</span>
+                     <span class="option-item-price-value is-accent">${priceValue}</span>`
+                  : `<span class="option-item-price-value is-accent">${catalogPrice}</span>`}
+              `
+              : `
+                <span class="option-item-price-value ${hasOverride ? "is-muted" : "is-accent"}">${catalogPrice}</span>
+                <input class="control" type="number" step="1" min="0" aria-label="Новая цена" data-item-field="price" data-item-id="${itemKey}" value="${priceValue}" />
+              `}
           </div>
           ${editable ? `
-            <button class="btn btn-icon" type="button" data-item-remove="${itemKey}" title="Удалить" aria-label="Удалить пункт"><i class="fas fa-times"></i></button>
-          ` : "<div></div>"}
+            <button class="option-row-remove" type="button" data-item-remove="${itemKey}" title="Удалить" aria-label="Удалить пункт"><i class="fas fa-times"></i></button>
+          ` : ""}
         </div>
       `;
     }).join("");
+
+    if (editable && showItemLimits) {
+      // ensure min/max are valid on initial render
+      optionItemsList.querySelectorAll(".option-item-row").forEach((row) => validateItemQtyBounds(row));
+    }
 
     if (!editable) {
       refreshOpenAccordions();
@@ -1167,6 +1295,10 @@
           } else if (field === "qty_max") {
             item.qty_max = input.value === "" ? 1 : Number(input.value);
           }
+          if (field === "qty_min" || field === "qty_max") {
+            validateItemQtyBounds(input.closest(".option-item-row"));
+            renderOptionHeader();
+          }
           return;
         }
 
@@ -1189,6 +1321,10 @@
           }
         }, 400);
         debounceMap.set(itemId, timer);
+        if (field === "qty_min" || field === "qty_max") {
+          validateItemQtyBounds(input.closest(".option-item-row"));
+          renderOptionHeader();
+        }
       });
     });
     refreshOpenAccordions();
@@ -1210,7 +1346,7 @@
           <div class="option-assignment-title">
             <div class="options-row-title">${escapeHtml(assignment.product_name || assignment.name || "")}</div>
           </div>
-          ${editable ? `<button class="btn btn-icon" type="button" data-assignment-remove="${assignmentKey}" title="Удалить"><i class="fas fa-times"></i></button>` : ""}
+          ${editable ? `<button class="option-row-remove" type="button" data-assignment-remove="${assignmentKey}" title="Удалить" aria-label="Удалить назначение"><i class="fas fa-times"></i></button>` : ""}
         </div>
       `;
     }).join("");
@@ -1249,9 +1385,9 @@
     if (optionLevelPicker) optionLevelPicker.classList.add("hidden");
 
     if (state.optionPanel.mode === "create") {
-      fillOptionGroupForm(state.optionDraft.group);
+      fillOptionGroupForm(state.optionDraft.group, state.optionDraft.items || []);
     } else if (state.optionGroupDetails?.group) {
-      fillOptionGroupForm(state.optionGroupDetails.group);
+      fillOptionGroupForm(state.optionGroupDetails.group, state.optionGroupDetails.items || []);
     }
 
     if (state.optionPanel.mode === "view") {
@@ -1389,6 +1525,7 @@
     }
     // keep selection on reopen
     state.optionPanel.pickerSelection = existingSelection;
+    state.optionPanel.pickerInitialSelection = new Set(existingSelection);
     state.optionPanel.pickerCategoryId = state.catalogCategories[0] ? Number(state.catalogCategories[0].id) : null;
     state.optionPanel.pickerQuery = "";
     if (optionPickerSearch) optionPickerSearch.value = "";
@@ -1396,7 +1533,21 @@
     renderOptionPickerLevel();
   }
 
+  function isSameSelection(a, b) {
+    if (a.size !== b.size) return false;
+    for (const id of a) {
+      if (!b.has(id)) return false;
+    }
+    return true;
+  }
+
   async function applyOptionPickerSelection() {
+    if (isSameSelection(state.optionPanel.pickerSelection, state.optionPanel.pickerInitialSelection)) {
+      // close picker silently if nothing changed
+      state.optionPanel.level = "group";
+      renderOptionGroupLevel();
+      return;
+    }
     const selectedIds = Array.from(state.optionPanel.pickerSelection);
     if (!selectedIds.length) {
       state.optionPanel.level = "group";
@@ -1427,8 +1578,8 @@
           target_product_id: id,
           price_mode: "from_target",
           price_value: null,
-          qty_min: getOptionGroupSelectionType() === "single" ? 1 : 1,
-          qty_max: getOptionGroupSelectionType() === "single" ? 1 : 1,
+          qty_min: 1,
+          qty_max: 1,
           sort_order: idx * 10,
         }));
         await apiAddGroupItems(state.selectedOptionGroupId, payload);
@@ -1454,10 +1605,7 @@
         });
         state.optionPanel.itemsDirty = true;
       } else if (state.selectedOptionGroupId) {
-        const res = await apiAddGroupAssignments(state.selectedOptionGroupId, selectedIds);
-        if (res.skipped && res.skipped.length) {
-          alert("Некоторые товары уже добавлены.");
-        }
+        await apiAddGroupAssignments(state.selectedOptionGroupId, selectedIds);
         await loadOptionGroupDetails(state.selectedOptionGroupId);
         await loadOptionGroups();
         renderOptionGroupsList();
@@ -1539,9 +1687,29 @@
     renderOptionGroupLevel();
   }
 
+  function cancelOptionEdit() {
+    if (state.optionPanel.mode === "edit") {
+      // return to view without closing the panel
+      state.optionPanel.mode = "view";
+      state.optionPanel.itemsDirty = false;
+      renderOptionGroupLevel();
+      return;
+    }
+    if (state.optionPanel.mode === "create") {
+      closeOptionDetails();
+    }
+  }
+
   async function saveOptionGroup() {
     if (!optionGroupForm) return;
-    const payload = getOptionGroupFormValues();
+    const formValues = getOptionGroupFormValues();
+    const selectionUi = formValues.selection_type;
+    const payload = {
+      ...formValues,
+      selection_type: getSelectionPayloadType(selectionUi),
+      min_select: selectionUi === "multiple_group" ? formValues.min_select : 0,
+      max_select: selectionUi === "multiple_group" ? formValues.max_select : null,
+    };
 
     if (!payload.title) {
       optionGroupTitleInput?.focus();
@@ -1555,8 +1723,8 @@
           target_product_id: item.id,
           price_mode: isFixed ? "fixed" : "from_target",
           price_value: isFixed ? Number(item.newPrice) : null,
-          qty_min: payload.selection_type === "single" ? 1 : (item.qty_min ?? 1),
-          qty_max: payload.selection_type === "single" ? 1 : (item.qty_max ?? 1),
+          qty_min: selectionUi === "multiple_item" ? (item.qty_min ?? 1) : 1,
+          qty_max: selectionUi === "multiple_item" ? (item.qty_max ?? 1) : 1,
           sort_order: idx * 10,
         };
       });
@@ -2505,8 +2673,21 @@
     if (optionGroupSelectionInput) {
       optionGroupSelectionInput.addEventListener("change", () => {
         updateOptionGroupSelectionUi();
-        // show qty controls immediately for "multiple"
+        // show qty controls immediately for selection type switch
         renderOptionItems(getOptionItemsSource());
+        renderOptionHeader();
+      });
+    }
+
+    if (optionGroupActiveInput) {
+      optionGroupActiveInput.addEventListener("change", () => {
+        handleOptionActiveToggle(optionGroupActiveInput.checked);
+      });
+    }
+
+    if (optionHeaderActiveInput) {
+      optionHeaderActiveInput.addEventListener("change", () => {
+        handleOptionActiveToggle(optionHeaderActiveInput.checked);
       });
     }
 
@@ -2568,6 +2749,10 @@
       optionHeaderCloseBtn.addEventListener("click", () => {
         if (state.optionPanel.level === "picker") {
           closeOptionPicker();
+          return;
+        }
+        if (state.optionPanel.mode !== "view") {
+          cancelOptionEdit();
           return;
         }
         closeOptionDetails();

--- a/views/partials/products/info.ejs
+++ b/views/partials/products/info.ejs
@@ -22,6 +22,11 @@
       </div>
 
       <div class="product-header-actions hidden" id="optionHeaderActions">
+        <label class="switch switch-compact option-header-switch" id="optionHeaderActiveSwitch">
+          <input class="switch-input" type="checkbox" id="optionHeaderActiveInput" aria-label="Активна" />
+          <span class="switch-ui" aria-hidden="true"></span>
+          <span class="switch-text">Активна</span>
+        </label>
         <button class="btn btn-icon hidden" id="optionHeaderBackBtn" type="button" title="Назад" aria-label="Назад">
           <i class="fas fa-arrow-left"></i>
         </button>
@@ -143,19 +148,19 @@
       <div id="optionLevelGroup">
         <form id="optionGroupForm" class="form-grid" autocomplete="off">
           <div class="option-group-section">
-            <div class="section-title">Группа</div>
+          <div class="section-title">Группа</div>
 
-            <div>
-              <label class="field-label" for="optionGroupTitle">Название *</label>
-              <input class="control" id="optionGroupTitle" name="title" type="text" required />
-            </div>
-
-            <div class="form-row-2">
-              <div>
+            <div class="option-group-row">
+              <div class="option-group-title-field">
+                <label class="field-label" for="optionGroupTitle">Название *</label>
+                <input class="control" id="optionGroupTitle" name="title" type="text" required />
+              </div>
+              <div class="option-group-select-field">
                 <label class="field-label" for="optionGroupSelectionType">Тип выбора</label>
                 <select class="control" id="optionGroupSelectionType" name="selection_type">
                   <option value="single">Один</option>
-                  <option value="multiple">Несколько</option>
+                  <option value="multiple_group">Несколько (лимит группы)</option>
+                  <option value="multiple_item">Несколько (лимит на товар)</option>
                 </select>
               </div>
             </div>


### PR DESCRIPTION
### Motivation

- Сделать UI группы опций соответствующим трём режимам выбора: `single`, `multiple_group`, `multiple_item` и мгновенно отражать смену типа в интерфейсе без сохранения.  
- Показывать/скрывать и валидировать min/max только там, где это требуется, не менять API и payload’ы.  
- Избежать сдвигов layout при появлении крестика удаления и обеспечить компактное, стабильное отображение строк пунктов/назначений.  
- Добавить синхронизированный свитч «Активна» в хедер и в форму, с моментальным апдейтом на бэкенде и откатом при ошибке.

### Description

- UI: в `views/partials/products/info.ejs` перестроена строка формы — `Название` и `Тип выбора` теперь в одной строке, и в `select#optionGroupSelectionType` добавлены опции `multiple_group` и `multiple_item`.  
- Логика: в `static/js/products.js` добавлены вспомогательные функции `getSelectionUiTypeFromGroup`, `getSelectionUiTypeFromItems` и `getSelectionPayloadType`, рефакторинг `getOptionGroupSelectionType`/`getOptionGroupFormValues` для работы с UI-типами и преобразования в payload (оставляя бэкенд-поле `selection_type` в формате `single|multiple`).  
- Пункты/назначения: рендер строк обновлён — компактное отображение цен (целые числа через `formatPriceInteger`), при `multiple_item` показываются инпуты `min`/`max` (фиксированная компактная ширина) с валидацией `min ≤ max` (`validateItemQtyBounds`), появление overlay-крестика удаления сделано абсолютным (`.option-row-remove`) чтобы не сдвигать layout.  
- Active switch & picker: добавлен свитч в хедер (`optionHeaderActiveSwitch`) и синхронизация со скрытым полем формы (`syncOptionActiveSwitches`), асинхронный апдейт `handleOptionActiveToggle` с отключением свитча на время запроса и `showToast` при ошибке; выбор товаров в picker теперь сохраняет начальную селекцию и закрывается без alert’ов если выбор не изменился.  
- Небольшие CSS-правки в `static/css/style.css` для безопасного `ellipsis`, фиксированных ширин полей, правого padding’а строк и toast-стилей; минимальные изменения в поведении кнопок/заголовка (`renderOptionHeader`).

### Testing

- Запущен dev-сервер: `node server.js` — сервер слушал `:3000`, но подключение к БД завершилось с `ECONNREFUSED` в текущем окружении (ошибка окружения, не связанная с изменениями UI).  
- Снимок страницы сделан автоматическим скриптом Playwright и успешно сохранил скриншот `/dashboard/products` (артефакт создан).  
- Нет unit/integration тестов; изменения проверялись через локальный запуск и визуальную проверку (см. скриншот).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696260e058f4832ab50f07971f4849e7)